### PR TITLE
Refactor: Collector now sends Review data with address in it. Analyze…

### DIFF
--- a/Analyzer/src/main/kotlin/com/tastecompass/analyzer/service/AnalyzerServiceImpl.kt
+++ b/Analyzer/src/main/kotlin/com/tastecompass/analyzer/service/AnalyzerServiceImpl.kt
@@ -41,7 +41,11 @@ class AnalyzerServiceImpl(
             throw e
         }
 
-        val geo = kakaomapClient.geocode(openaiAnalysisResult.address)
+        val geo = if(review.address.isNotBlank()) {
+            kakaomapClient.geocode(openaiAnalysisResult.address)
+        } else {
+            kakaomapClient.geocode(review.address)
+        }
         logger.debug("Geocoded address='{}', x={}, y={}", geo.normalizedAddress, geo.x, geo.y)
 
         FullAnalysisResult(

--- a/Analyzer/src/test/kotlin/com/tastecompass/analyzer/service/AnalyzerServiceMockTest.kt
+++ b/Analyzer/src/test/kotlin/com/tastecompass/analyzer/service/AnalyzerServiceMockTest.kt
@@ -36,6 +36,7 @@ class AnalyzerServiceMockTest {
         val review = Review(
             text = "This restaurant had amazing sushi!",
             source = "naver",
+            address = "포항시 남구 이인로 90",
             url = "naver.com/test"
         )
         val expectedAnalysisResult = OpenAIAnalysisResult(
@@ -77,6 +78,7 @@ class AnalyzerServiceMockTest {
         val review = Review(
             text = "Great ramen.",
             source = "blog",
+            address = "포항시 남구 이인로 90",
             url = "blog.com/test"
         )
         whenever(openaiClient.chat(any())).thenThrow(RuntimeException())
@@ -97,6 +99,7 @@ class AnalyzerServiceMockTest {
         val review = Review(
             text = "Nice cafe",
             source = "tistory",
+            address = "포항시 남구 이인로 90",
             url = "tistory.com/test"
         )
 

--- a/Analyzer/src/test/kotlin/com/tastecompass/analyzer/service/AnalyzerServiceTest.kt
+++ b/Analyzer/src/test/kotlin/com/tastecompass/analyzer/service/AnalyzerServiceTest.kt
@@ -126,6 +126,7 @@ class AnalyzerServiceTest {
         val review = Review(
             source = "tistory",
             url = "tistory.com",
+            address = "포항시 남구 이인로 90",
             text = text
         )
         val result = analyzerService.analyze(review)

--- a/Domain/src/main/kotlin/com/tastecompass/domain/entity/Review.kt
+++ b/Domain/src/main/kotlin/com/tastecompass/domain/entity/Review.kt
@@ -3,7 +3,6 @@ package com.tastecompass.domain.entity
 data class Review(
     val source: String,
     val url: String,
-    val text: String,
-    val x: Double = 0.0,
-    val y: Double = 0.0
+    val address: String,
+    val text: String
 )


### PR DESCRIPTION
…r set analysis result's address as the result of KakaoMapClient's geocode with it. If there's no address from collector, it is same as before. #3

Added address field to Review being fit the change of Analyzer's inner logic.